### PR TITLE
Silences console error spam when object can't be cloned

### DIFF
--- a/src/integrations/chrome/scripts/backend.js
+++ b/src/integrations/chrome/scripts/backend.js
@@ -35,13 +35,23 @@ function handshake(e) {
         listeners.push(listener);
       },
       send(data) {
-        window.postMessage(
-          {
-            source: 'relay-devtools-backend',
-            payload: data,
-          },
-          '*',
-        );
+        try {
+          window.postMessage(
+            {
+              source: 'relay-devtools-backend',
+              payload: data,
+            },
+            '*',
+          );
+        } catch (e) {
+          window.postMessage(
+            {
+              source: 'relay-devtools-backend',
+              payload: {},
+            },
+            '*',
+          );
+        }
       },
     });
 


### PR DESCRIPTION
This PR is mainly just an "additional information" PR for #20 

There has got to be a better solution to this, but this is how I am silencing errors related to [#20](https://github.com/relayjs/relay-devtools/issues/20)