### PR TITLE
add check for null id/record (fixes #30)

### DIFF
--- a/src/backend/EnvironmentAgent.js
+++ b/src/backend/EnvironmentAgent.js
@@ -139,6 +139,9 @@ export default class EnvironmentAgent {
     matchType: MatchType,
   ): {[id: string]: string} {
     function isMatching(id: DataID, record: Record): boolean {
+      if (!id || !record) {
+        return false;
+      }
       if (matchType === 'idtype') {
         return (
           id.includes(matchStr) ||


### PR DESCRIPTION
i think this has to do with our use of local schema? seems like this is thrown if we do anything with the local schema before we request something remotely. 