### PR TITLE
Fix _objectSpread error and problem of stucking in loading

### DIFF
--- a/src/backend/GlobalHook.js
+++ b/src/backend/GlobalHook.js
@@ -227,10 +227,11 @@ export function installGlobalHook(target: any): boolean {
             return observable.do({
               unsubscribe: () =>
                 // Produce a mirrored "Unsubscribe" network event.
-                agent._networkEvent({
-                  ...lastNetworkEvent,
-                  eventName: 'Unsubscribe',
-                }),
+                agent._networkEvent(
+                  Object.assign({}, lastNetworkEvent, {
+                    eventName: 'Unsubscribe',
+                  }),
+                ),
             });
           };
         };

--- a/src/frontend/api/BridgeAPI.js
+++ b/src/frontend/api/BridgeAPI.js
@@ -25,6 +25,7 @@ export default class BridgeAPI {
   _changeCallbacks: {[environment: string]: Array<() => void>};
   _recordSummaryCache: {[environment: string]: {[id: string]: string}};
   _updateEvents: Array<UpdateEvent>;
+  _registered: boolean;
 
   constructor(bridge: Bridge): void {
     this._bridge = bridge;
@@ -34,11 +35,14 @@ export default class BridgeAPI {
     this._recordSummaryCache = {};
     // $FlowFixMe
     this._updateEvents = {};
+    this._registered = false;
 
     this._bridge.on('register', () => {
+      this._registered = true;
       // $FlowFixMe
       this._onRegisterListeners.forEach(cb => cb());
     });
+
 
     // this._bridge.on('log', (event, name, data) => {
 
@@ -165,5 +169,8 @@ export default class BridgeAPI {
   onRegister(callback: $FlowFixMe) {
     // $FlowFixMe
     this._onRegisterListeners.push(callback);
+    if (this._registered) {
+      callback();
+    }
   }
 }

--- a/src/frontend/index.js
+++ b/src/frontend/index.js
@@ -21,7 +21,7 @@ import ReactDOM from 'react-dom';
 import API from './api/BridgeAPI';
 import configureStore from './redux/store/configureStore';
 import App from './components/App';
-// import RelayDetector from './containers/RelayDetector';
+import RelayDetector from './components/RelayDetector';
 
 let app = null;
 
@@ -54,9 +54,9 @@ function initApp(shell: ShellType) {
     const store = configureStore(api);
     app = 'devtools-root';
     ReactDOM.render(
-      // <RelayDetector API={api}>
-      <App store={store} api={api} />,
-      // </RelayDetector>
+      <RelayDetector API={api}>
+        <App store={store} api={api} />
+      </RelayDetector>,
       // $FlowFixMe
       document.getElementById('devtools-root'),
     );

--- a/src/integrations/chrome/manifest.json
+++ b/src/integrations/chrome/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 2,
   "name": "Relay Developer Tools",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "short_name": "Relay Developer Tools",
   "description": "Developer Tools extension to inspect Relay store and how it changes.",
   "browser_action": {


### PR DESCRIPTION
This PR:
1. Fix the error message of _objectSpread by using Object.assign. 
2. Fix the issue where the devtool sometimes stuck in Connection to Relay. 
