### PR TITLE
Add package name

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "version": "1.0.0",
+  "name": "relay-devtools",
   "repository": "relayjs/relay-devtools",
   "license": "MIT",
   "private": true,


### PR DESCRIPTION
Not having the package name doesn't allow us to install the package from git remote