### PR TITLE
Basic support for store explorer

### DIFF
--- a/src/backend/EnvironmentWrapper.js
+++ b/src/backend/EnvironmentWrapper.js
@@ -33,10 +33,22 @@ export function attach(
     }
   };
 
+  const store = environment.getStore();
+  const originalPublish = store.publish.bind(store);
+  store.publish = (...args) => {
+    const result = originalPublish(...args);
+
+    const records = store.getSource().toJSON();
+    hook.emit('environment.event', { name: 'store.updated', records });
+
+    return result;
+  };
+
   function cleanup() {
     // We don't patch any methods so there is no cleanup.
     // $FlowFixMe
     environment.__log = originalLog;
+    store.publish = originalPublish;
   }
 
   function flushInitialOperations() {

--- a/src/backend/types.js
+++ b/src/backend/types.js
@@ -9,8 +9,20 @@
 
 export type EnvironmentID = number;
 
+export type RelayRecordSource = {
+  getRecordIDs: () => string,
+  get: (id: string) => any,
+  toJSON: () => any,
+};
+
+export type RelayStore = {
+  publish: (...args: any[]) => any,
+  getSource: () => RelayRecordSource,
+};
+
 export type RelayEnvironment = {
   execute: (options: any) => any,
+  getStore: () => RelayStore,
 };
 
 export type EnvironmentWrapper = {

--- a/src/devtools/store.js
+++ b/src/devtools/store.js
@@ -37,6 +37,7 @@ export default class Store extends EventEmitter<{|
   _bridge: FrontendBridge;
 
   _environmentEvents: Array<LogEvent> = [];
+  _relayStoreRecords: any;
 
   constructor(bridge: FrontendBridge) {
     super();
@@ -49,8 +50,19 @@ export default class Store extends EventEmitter<{|
     return this._environmentEvents;
   }
 
+  getRecords(): any {
+    return this._relayStoreRecords;
+  }
+
   onBridgeEvents = (events: Array<LogEvent>) => {
-    this._environmentEvents.push(...events);
+    for (const event of events) {
+      if (event.name === 'store.updated') {
+        this._relayStoreRecords = event.records;
+      } else {
+        this._environmentEvents.push(event);
+      }
+    }
+
     this.emit('mutated');
   };
 

--- a/src/devtools/views/Components/SearchInput.css
+++ b/src/devtools/views/Components/SearchInput.css
@@ -1,0 +1,24 @@
+.SearchInput {
+  flex: 1 1;
+  display: flex;
+  align-items: center;
+  padding: 0.5rem 1rem;
+}
+
+.Input {
+  flex: 1 1 100px;
+  width: 100px;
+  font-size: var(--font-size-sans-large);
+  outline: none;
+  border: none;
+  background-color: var(--color-background);
+  color: var(--color-text);
+  padding-left: 1.5rem;
+  margin-left: -1rem;
+}
+
+.InputIcon {
+  pointer-events: none;
+  z-index: 2;
+  color: var(--color-dimmer);
+}

--- a/src/devtools/views/Components/SearchInput.js
+++ b/src/devtools/views/Components/SearchInput.js
@@ -1,0 +1,67 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+import * as React from 'react';
+import { useCallback, useEffect, useRef } from 'react';
+import Icon from '../Icon';
+
+import styles from './SearchInput.css';
+
+type Props = {|
+  searchText: string,
+  onTextChange: (text: string) => void,
+|};
+
+export default function SearchInput({ searchText, onChange }: Props) {
+  const inputRef = useRef<HTMLInputElement | null>(null);
+
+  const handleTextChange = useCallback(
+    ({ currentTarget }) => onChange(currentTarget.value),
+    [onChange]
+  );
+
+  // Auto-focus search input
+  useEffect(() => {
+    if (inputRef.current === null) {
+      return () => {};
+    }
+
+    const handleWindowKey = (event: KeyboardEvent) => {
+      const { key, metaKey } = event;
+      if (key === 'f' && metaKey) {
+        if (inputRef.current !== null) {
+          inputRef.current.focus();
+          event.preventDefault();
+          event.stopPropagation();
+        }
+      }
+    };
+
+    // It's important to listen to the ownerDocument to support the browser extension.
+    // Here we use portals to render individual tabs (e.g. Profiler),
+    // and the root document might belong to a different window.
+    const ownerDocument = inputRef.current.ownerDocument;
+    ownerDocument.addEventListener('keydown', handleWindowKey);
+
+    return () => ownerDocument.removeEventListener('keydown', handleWindowKey);
+  }, [inputRef]);
+
+  return (
+    <div className={styles.SearchInput}>
+      <Icon className={styles.InputIcon} type="search" />
+      <input
+        className={styles.Input}
+        onChange={handleTextChange}
+        placeholder="Search (ID or type)"
+        ref={inputRef}
+        value={searchText}
+      />
+    </div>
+  );
+}

--- a/src/devtools/views/Components/SearchInput.js
+++ b/src/devtools/views/Components/SearchInput.js
@@ -15,7 +15,7 @@ import styles from './SearchInput.css';
 
 type Props = {|
   searchText: string,
-  onTextChange: (text: string) => void,
+  onChange: (text: string) => void,
 |};
 
 export default function SearchInput({ searchText, onChange }: Props) {

--- a/src/devtools/views/StoreInspector/StoreInspector.css
+++ b/src/devtools/views/StoreInspector/StoreInspector.css
@@ -1,0 +1,85 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+.StoreInspector {
+  width: 100%;
+  height: 100%;
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+  font-family: var(--font-family-sans);
+  font-size: var(--font-size-sans-normal);
+  background-color: var(--color-background);
+  color: var(--color-text);
+}
+
+.Toolbar {
+  padding: 0 0.25rem;
+  flex: 0;
+  display: flex;
+  align-items: center;
+  border-bottom: 1px solid var(--color-border);
+}
+
+.Spacer {
+  flex: 1;
+}
+
+.SectionTitle {
+  color: #616161;
+  font-weight: bold;
+}
+
+.SectionContent {
+  margin-left: 20px;
+  white-space: pre-wrap;
+}
+
+.Records {
+  border-right: 1px solid #d0d0d0;
+  color: #303942;
+  flex: 1;
+  overflow: scroll;
+}
+
+.Content {
+  display: flex;
+  height: 100%;
+  overflow: hidden;
+}
+
+.Record {
+  background: #ffffff;
+  cursor: pointer;
+  padding: 1px 4px;
+}
+.Record:hover {
+  background: #f1f6fd;
+}
+.Record:nth-child(2n) {
+  background: #f5f5f5;
+}
+.Record:nth-child(2n):hover {
+  background: #eef3fa;
+}
+.Record.SelectedRequest,
+.Record.SelectedRequest:hover {
+  background: #1a73e8;
+  color: white;
+}
+.Record::before {
+  display: inline-block;
+  width: 1em;
+  content: '';
+}
+
+.RecordDetails {
+  flex: 3;
+  overflow: scroll;
+  padding: 3px;
+}

--- a/src/devtools/views/StoreInspector/StoreInspector.js
+++ b/src/devtools/views/StoreInspector/StoreInspector.js
@@ -15,16 +15,16 @@ import SearchInput from '../Components/SearchInput';
 import portaledContent from '../portaledContent';
 import styles from './StoreInspector.css';
 
-function getRecordData(records, record) {
+function getRecordData(records: { [string]: any }, record: any): any {
   if (Array.isArray(record)) {
     return record.map(r => getRecordData(records, r));
   } else if (record !== null && typeof record === 'object') {
-    let result = {};
+    let result: any = {};
     for (const [key, value] of Object.entries(record)) {
       if (key === '__ref') {
-        result = getRecordData(records, records[value]);
+        result = getRecordData(records, records[(value: any)]);
       } else if (key === '__refs') {
-        result = value.map(r => getRecordData(records, records[r]));
+        result = (value: any).map(r => getRecordData(records, records[r]));
       } else {
         result[key] = getRecordData(records, value);
       }

--- a/src/devtools/views/StoreInspector/StoreInspector.js
+++ b/src/devtools/views/StoreInspector/StoreInspector.js
@@ -7,6 +7,136 @@
  * @flow
  */
 
-export default function StoreInspector(props: {}) {
-  return 'Store Inspector';
+import React, { useContext, useEffect, useState, useCallback } from 'react';
+import { StoreContext } from '../context';
+import InspectedElementTree from '../Components/InspectedElementTree';
+import SearchInput from '../Components/SearchInput';
+
+import portaledContent from '../portaledContent';
+import styles from './StoreInspector.css';
+
+function getRecordData(records, record) {
+  if (Array.isArray(record)) {
+    return record.map(r => getRecordData(records, r));
+  } else if (record !== null && typeof record === 'object') {
+    let result = {};
+    for (const [key, value] of Object.entries(record)) {
+      if (key === '__ref') {
+        result = getRecordData(records, records[value]);
+      } else if (key === '__refs') {
+        result = value.map(r => getRecordData(records, records[r]));
+      } else {
+        result[key] = getRecordData(records, value);
+      }
+    }
+    return result;
+  } else {
+    return record;
+  }
 }
+
+function Section(props: {| title: string, children: React$Node |}) {
+  return (
+    <>
+      <div className={styles.SectionTitle}>{props.title}</div>
+      <div className={styles.SectionContent}>{props.children}</div>
+    </>
+  );
+}
+
+function RecordsList({ records, selectedRecordID, setSelectedRecordID }) {
+  const [searchText, setSearchText] = useState('');
+
+  const handleSearchTextChange = useCallback(text => {
+    setSearchText(text);
+  }, []);
+
+  const recordRows = Object.keys(records)
+    .filter(
+      recordID =>
+        searchText.length === 0 ||
+        recordID.startsWith(searchText) ||
+        records[recordID].__typename.startsWith(searchText)
+    )
+    .map(recordID => {
+      return (
+        <div
+          key={recordID}
+          onClick={() => {
+            setSelectedRecordID(recordID);
+          }}
+          className={`${styles.Record} ${
+            recordID === selectedRecordID ? styles.SelectedRequest : ''
+          }`}
+        >
+          {recordID}
+        </div>
+      );
+    });
+
+  return (
+    <div className={styles.Records}>
+      <SearchInput searchText={searchText} onChange={handleSearchTextChange} />
+      {recordRows}>
+    </div>
+  );
+}
+
+function RecordDetails({ record, records }) {
+  if (record == null) {
+    return <div className={styles.RecordDetails}>No record selected</div>;
+  }
+
+  const { __id, __typename, ...data } = record;
+
+  return (
+    <div className={styles.RecordDetails}>
+      <Section title="ID">{__id}</Section>
+      <Section title="Type">{__typename}</Section>
+      <InspectedElementTree
+        label="Data"
+        data={getRecordData(records, data)}
+        showWhenEmpty
+      />
+    </div>
+  );
+}
+
+function StoreInspector(props: {| +portalContainer: mixed |}) {
+  const store = useContext(StoreContext);
+
+  const [, forceUpdate] = useState({});
+
+  useEffect(() => {
+    const onMutated = () => {
+      forceUpdate({});
+    };
+    store.addListener('mutated', onMutated);
+    return () => {
+      store.removeListener('mutated', onMutated);
+    };
+  }, [store]);
+
+  const records = store.getRecords();
+
+  const [selectedRecordID, setSelectedRecordID] = useState(null);
+
+  if (records == null) {
+    return 'Loading...';
+  }
+
+  return (
+    <div className={styles.StoreInspector}>
+      <div className={styles.Content}>
+        <RecordsList
+          records={records}
+          selectedRecordID={selectedRecordID}
+          setSelectedRecordID={setSelectedRecordID}
+        />
+        <RecordDetails records={records} record={records[selectedRecordID]} />
+      </div>
+    </div>
+  );
+}
+
+export default portaledContent(StoreInspector);


### PR DESCRIPTION
This is a super basic implementation of the store browser. It also supports search by id or type.

![giphy](https://user-images.githubusercontent.com/2677334/78280888-cdf6ea80-74e7-11ea-8bb1-f5f3cb559b74.gif)

#### Caveats

It currently sends full store data on changes which potentially could be slow for very large stores or very frequent updates. Ideally we'd implement some sort of diffing to only send changes but that adds a lot of complexity to the bridge / store layer.