### PR TITLE
Display all tabs in one panel

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,7 +64,8 @@
     "test:firefox": "node ./shells/browser/firefox/test",
     "test:standalone": "cd packages/relay-devtools && yarn start",
     "typecheck": "flow check",
-    "relay": "relay-compiler"
+    "relay": "relay-compiler",
+    "watch:chrome:frontend": "cross-env NODE_ENV=development node ./shells/browser/chrome/watch"
   },
   "devEngines": {
     "node": "10.x || 11.x"

--- a/shells/browser/chrome/watch.js
+++ b/shells/browser/chrome/watch.js
@@ -1,0 +1,33 @@
+#!/usr/bin/env node
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+const archiver = require('archiver');
+const { execSync } = require('child_process');
+const { readFileSync, writeFileSync, createWriteStream } = require('fs');
+const { copy, ensureDir, move, remove } = require('fs-extra');
+const { join } = require('path');
+const { getGitCommit } = require('../../utils');
+
+const webpackPath = join(
+  __dirname,
+  '..',
+  '..',
+  '..',
+  'node_modules',
+  '.bin',
+  'webpack'
+);
+const binPath = join(__dirname, 'build', 'unpacked', 'build');
+execSync(
+  `${webpackPath} --config ../shared/webpack.config.js --output-path ${binPath} --watch`,
+  {
+    cwd: join(__dirname, '..', 'shared'),
+    env: process.env,
+    stdio: 'inherit',
+  }
+);

--- a/src/devtools/views/DevTools.js
+++ b/src/devtools/views/DevTools.js
@@ -46,9 +46,11 @@ export type Props = {|
   // Because of this, the extension needs to be able to change which tab is active/rendered.
   overrideTab?: TabID,
 
+  // TODO: Cleanup multi-tabs in webextensions
   // To avoid potential multi-root trickiness, the web extension uses portals to render tabs.
   // The root <DevTools> app is rendered in the top-level extension window,
   // but individual tabs (e.g. Components, Profiling) can be rendered into portals within their browser panels.
+  rootContainer?: Element,
   networkPortalContainer?: Element,
   settingsPortalContainer?: Element,
   storeInspectorPortalContainer?: Element,
@@ -73,6 +75,7 @@ export default function DevTools({
   bridge,
   browserTheme = 'light',
   defaultTab = 'network',
+  rootContainer,
   networkPortalContainer,
   storeInspectorPortalContainer,
   overrideTab,
@@ -93,6 +96,7 @@ export default function DevTools({
         <ModalDialogContextController>
           <SettingsContextController
             browserTheme={browserTheme}
+            rootContainer={rootContainer}
             networkPortalContainer={networkPortalContainer}
             settingsPortalContainer={settingsPortalContainer}
           >

--- a/src/devtools/views/Settings/SettingsContext.js
+++ b/src/devtools/views/Settings/SettingsContext.js
@@ -35,6 +35,7 @@ type DocumentElements = Array<HTMLElement>;
 type Props = {|
   browserTheme: BrowserTheme,
   children: React$Node,
+  rootContainer?: Element,
   networkPortalContainer?: Element,
   settingsPortalContainer?: Element,
 |};
@@ -42,6 +43,7 @@ type Props = {|
 function SettingsContextController({
   browserTheme,
   children,
+  rootContainer,
   networkPortalContainer,
   settingsPortalContainer,
 }: Props) {
@@ -58,6 +60,11 @@ function SettingsContextController({
     const array: Array<HTMLElement> = [
       ((document.documentElement: any): HTMLElement),
     ];
+    if (rootContainer != null) {
+      array.push(
+        ((rootContainer.ownerDocument.documentElement: any): HTMLElement)
+      );
+    }
     if (networkPortalContainer != null) {
       array.push(
         ((networkPortalContainer.ownerDocument


### PR DESCRIPTION
In Relay, we will have multiple Relay environments,  so replicating react devtools won't work well when we need to show tabs for different environments.

This PR makes the Relay devtools show everything under one chrome panel.
![Screen Shot 2020-06-02 at 11 22 00 PM](https://user-images.githubusercontent.com/5868353/83592235-e4411700-a527-11ea-92fc-3f7c69502292.png)


Also adds a `watch:chrome:frontend` command to make the webpack watch the change for frontend files. So we don't need to run `build:extensions` everytime we make changes, when iterating and testing directly on the Chrome extension, 

