### PR TITLE
Update electron to the latest

### DIFF
--- a/packages/relay-devtools/package.json
+++ b/packages/relay-devtools/package.json
@@ -22,7 +22,7 @@
   },
   "dependencies": {
     "cross-spawn": "^7.0.1",
-    "electron": "^7.2.4",
+    "electron": "^11.4.6",
     "ip": "^1.1.4",
     "minimist": "^1.2.3",
     "relay-devtools-core": "^1.0.0",


### PR DESCRIPTION
This fixes the issue with installing relay-devtools on Apple Silicon machines