### PR TITLE
Fixed showing numbers as undefined in KeyValue component

### DIFF
--- a/src/devtools/views/StoreInspector/KeyValue.js
+++ b/src/devtools/views/StoreInspector/KeyValue.js
@@ -32,7 +32,7 @@ const REFS = '__refs';
 function getDisplayValue(value) {
   return typeof value === 'string'
     ? `"${value}"`
-    : typeof value === 'boolean'
+    : typeof value === 'boolean' || typeof value === 'number'
     ? value.toString()
     : value === null
     ? 'null'


### PR DESCRIPTION
This PR fixes showing numbers as `undefined` in Store Explorer. 