### PR TITLE
Use Node V20 in Github CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@v1
       - uses: actions/setup-node@v1
         with:
-          node-version: 12.x
+          node-version: 20.x
       - name: Install dependencies
         run: yarn install --frozen-lockfile
       - name: Check formatting


### PR DESCRIPTION
The CI job has been failing. Use the same version as what the relay repo is using https://github.com/facebook/relay/blob/main/.github/workflows/ci.yml

The CI no longer fails at the installing dependencies stage. It now fails at lint errors that needs to be addressed separately