### PR TITLE
Fix Window.postMessage Error

### DIFF
--- a/shells/browser/shared/src/backend.js
+++ b/shells/browser/shared/src/backend.js
@@ -53,7 +53,7 @@ function setup(hook: any) {
       window.postMessage(
         {
           source: 'relay-devtools-bridge',
-          payload: events,
+          payload: JSON.parse(JSON.stringify(events)),
         },
         '*'
       );


### PR DESCRIPTION
In our environment we are getting an issue when trying to communicate with the backend service worker. By making the object dumpable by serializing and deserializing, we have seems to have fixed the issue.